### PR TITLE
fixed crash on empty var block

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -60,6 +60,11 @@ func parseFile(fset *token.FileSet, filePath, template string) (af *ast.File, mo
 					}
 				}
 
+				// empty var block
+				if len(typ.Specs) == 0 {
+					return true
+				}
+
 				vs := typ.Specs[0].(*ast.ValueSpec)
 				if skipped[typ] || !vs.Names[0].IsExported() {
 					return true

--- a/testdata/empty_var_block.go
+++ b/testdata/empty_var_block.go
@@ -1,0 +1,5 @@
+package p
+
+var (
+	// Error
+)


### PR DESCRIPTION
Found & fixed a crash when gocmt encountered

```
var (
     // Something
)
```