### PR TITLE
Update main documentation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Go
+name: Test
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # gocmt - Add missing comment on exported function, method, type, constant, variable in go file
 
-![Build status](https://github.com/cuonglm/gocmt/workflows/Go/badge.svg?branch=master)
+![Build status](https://github.com/cuonglm/gocmt/actions/workflows/ci.yaml/badge.svg?branch=master)
+[![Go Reference](https://pkg.go.dev/badge/github.com/cuonglm/gocmt.svg)](https://pkg.go.dev/github.com/cuonglm/gocmt)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cuonglm/gocmt)](https://goreportcard.com/report/github.com/cuonglm/gocmt)
 
 # Installation

--- a/main.go
+++ b/main.go
@@ -1,3 +1,17 @@
+// gocmt adds missing comments on exported identifiers in Go source files.
+//
+// Usage:
+//
+//  gocmt [-i false|true] [-t "comment template"] [-d dir] [-p false|true]
+//
+// This tools exists because I have to work with some existed code base, which
+// is lack of documentation for many exported identifiers. Iterating over them
+// is time consuming and maybe not suitable at a stage of the project. So I
+// wrote this tool to quickly bypassing CI system. Once thing is settle, we can
+// lookback and fix missing comments.
+//
+// You SHOULD always write documentation for all your exported identifiers.
+
 package main
 
 import (


### PR DESCRIPTION
For adding more details why gocmt exists. While at it, also add badge to
pkg.go.dev, and point Github Action to workflow file.