### PR TITLE
add prefix match exclude feature

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -2,7 +2,7 @@
 //
 // Usage:
 //
-//  gocmt [-i] [-p] [-t "comment template"] [-d dir]
+//  gocmt [-i] [-p] [-t "comment template"] [-d dir] [-e exclude_dirs]
 //
 // This tools exists because I have to work with some existed code base, which
 // is lack of documentation for many exported identifiers. Iterating over them

--- a/helper.go
+++ b/helper.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"go/scanner"
 	"os"
 	"strings"
@@ -17,6 +18,14 @@ func printError(err error) {
 
 func walkFunc(path string, fi os.FileInfo, err error) error {
 	if err == nil && isGoFile(fi) {
+		// exclude path
+		for _, e := range excludeDirs {
+			if strings.HasPrefix(path, e) {
+				fmt.Fprintf(os.Stdout, "ignore %s\n", path)
+				return nil
+			}
+		}
+
 		err = processFile(path, *template, *inPlace)
 	}
 

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	defaultMode         = os.FileMode(0644)
 	tralingWsRegex      = regexp.MustCompile(`(?m)[\t ]+$`)
 	newlinesRegex       = regexp.MustCompile(`(?m)\n{3,}`)
+	excludeDirs         []string
 )
 
 var (
@@ -29,6 +30,8 @@ var (
 	template     = flag.String("t", "...", "Comment template")
 	dir          = flag.String("d", "", "Directory to process")
 	parenComment = flag.Bool("p", false, "Add comments to all const inside the parens if true")
+	exclude      = flag.String("e", "",
+		"Path to exclude(only support prefix match), such as 'pkg/xxx/', 'pkg/xxx/,pkg/yyy/', and so on")
 )
 
 func main() {
@@ -42,6 +45,10 @@ func usage() {
 
 func gocmtRun() int {
 	flag.Parse()
+
+	if *exclude != "" {
+		excludeDirs = strings.Split(*exclude, ",")
+	}
 
 	if *dir != "" {
 		if err := filepath.Walk(*dir, walkFunc); err != nil {

--- a/testdata/pkg/xxx/xxx.go
+++ b/testdata/pkg/xxx/xxx.go
@@ -1,0 +1,2 @@
+// auto generate, should ignore
+package xxx

--- a/testdata/pkg/yyy/yyy.go
+++ b/testdata/pkg/yyy/yyy.go
@@ -1,0 +1,1 @@
+package yyy


### PR DESCRIPTION
Add prefix match exclude feature, such as 
```bash
$ ./gocmt -d testdata/pkg -e 'testdata/pkg/xxx/'
ignore testdata/pkg/xxx/xxx.go
testdata/pkg/yyy/yyy.go no changes
```

or

```bashw
$ ./gocmt -d testdata/pkg -e 'testdata/pkg/xxx/,testdata/pkg/yyy/'
ignore testdata/pkg/xxx/xxx.go
ignore testdata/pkg/yyy/yyy.go
```