### PR TITLE
feature: modify existed comments if necessary

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -43,3 +43,31 @@ func isLineComment(comment *ast.CommentGroup) bool {
 func hasCommentPrefix(comment *ast.CommentGroup, prefix string) bool {
 	return strings.HasPrefix(strings.TrimSpace(comment.Text()), prefix)
 }
+
+func appendCommentGroup(list []*ast.CommentGroup, item *ast.CommentGroup) []*ast.CommentGroup {
+	ret := []*ast.CommentGroup{}
+	hasInsert := false
+	for _, group := range list {
+		if group.Pos() < item.Pos() {
+			ret = append(ret, group)
+			continue
+		}
+		if group.Pos() == item.Pos() {
+			ret = append(ret, item)
+			hasInsert = true
+			continue
+		}
+		if group.Pos() > item.Pos() {
+			if !hasInsert {
+				ret = append(ret, item)
+				hasInsert = true
+			}
+			ret = append(ret, group)
+			continue
+		}
+	}
+	if !hasInsert {
+		ret = append(ret, item)
+	}
+	return ret
+}

--- a/helper.go
+++ b/helper.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"go/ast"
 	"go/scanner"
 	"os"
 	"strings"
@@ -25,4 +26,16 @@ func walkFunc(path string, fi os.FileInfo, err error) error {
 	}
 
 	return nil
+}
+
+func isDouble(group *ast.CommentGroup) bool {
+	if group == nil {
+		return false
+	}
+	if len(group.List) == 0 {
+		return false
+	}
+	head := group.List[0].Text
+	head = strings.TrimSpace(head)
+	return strings.HasPrefix(head, "//")
 }

--- a/helper.go
+++ b/helper.go
@@ -28,14 +28,18 @@ func walkFunc(path string, fi os.FileInfo, err error) error {
 	return nil
 }
 
-func isLineComment(group *ast.CommentGroup) bool {
-	if group == nil {
+func isLineComment(comment *ast.CommentGroup) bool {
+	if comment == nil {
 		return false
 	}
-	if len(group.List) == 0 {
+	if len(comment.List) == 0 {
 		return false
 	}
-	head := group.List[0].Text
+	head := comment.List[0].Text
 	head = strings.TrimSpace(head)
 	return strings.HasPrefix(head, "//")
+}
+
+func hasPrefix(comment *ast.CommentGroup, prefix string) bool {
+	return strings.HasPrefix(strings.TrimSpace(comment.Text()), prefix)
 }

--- a/helper.go
+++ b/helper.go
@@ -28,7 +28,7 @@ func walkFunc(path string, fi os.FileInfo, err error) error {
 	return nil
 }
 
-func isDouble(group *ast.CommentGroup) bool {
+func isLineComment(group *ast.CommentGroup) bool {
 	if group == nil {
 		return false
 	}

--- a/helper.go
+++ b/helper.go
@@ -40,6 +40,6 @@ func isLineComment(comment *ast.CommentGroup) bool {
 	return strings.HasPrefix(head, "//")
 }
 
-func hasPrefix(comment *ast.CommentGroup, prefix string) bool {
+func hasCommentPrefix(comment *ast.CommentGroup, prefix string) bool {
 	return strings.HasPrefix(strings.TrimSpace(comment.Text()), prefix)
 }

--- a/parse.go
+++ b/parse.go
@@ -113,9 +113,7 @@ func addFuncDeclComment(fd *ast.FuncDecl, commentTemplate string) {
 		return
 	}
 	if fd.Doc != nil && isLineComment(fd.Doc) && !hasCommentPrefix(fd.Doc, fd.Name.Name) {
-		text := fmt.Sprintf(commentBase+"%s", fd.Name, strings.TrimSpace(fd.Doc.Text()))
-		pos := fd.Doc.Pos()
-		fd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
+		modifyComment(fd.Doc, fd.Name.Name)
 		return
 	}
 }
@@ -131,9 +129,7 @@ func addValueSpecComment(gd *ast.GenDecl, vs *ast.ValueSpec, commentTemplate str
 		return
 	}
 	if gd.Doc != nil && isLineComment(gd.Doc) && !hasCommentPrefix(gd.Doc, vs.Names[0].Name) {
-		text := fmt.Sprintf(commentBase+"%s", vs.Names[0].Name, strings.TrimSpace(gd.Doc.Text()))
-		pos := gd.Doc.Pos()
-		gd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
+		modifyComment(gd.Doc, vs.Names[0].Name)
 		return
 	}
 }
@@ -150,9 +146,7 @@ func addParenValueSpecComment(vs *ast.ValueSpec, commentTemplate string) {
 		return
 	}
 	if vs.Doc != nil && isLineComment(vs.Doc) && !hasCommentPrefix(vs.Doc, vs.Names[0].Name) {
-		text := fmt.Sprintf(commentBase+"%s", vs.Names[0].Name, strings.TrimSpace(vs.Doc.Text()))
-		pos := vs.Doc.Pos()
-		vs.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
+		modifyComment(vs.Doc, vs.Names[0].Name)
 		return
 	}
 }
@@ -168,9 +162,14 @@ func addTypeSpecComment(gd *ast.GenDecl, ts *ast.TypeSpec, commentTemplate strin
 		return
 	}
 	if gd.Doc != nil && isLineComment(gd.Doc) && !hasCommentPrefix(gd.Doc, ts.Name.Name) {
-		text := fmt.Sprintf(commentBase+"%s", ts.Name.Name, strings.TrimSpace(gd.Doc.Text()))
-		pos := gd.Doc.Pos()
-		gd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
+		modifyComment(gd.Doc, ts.Name.Name)
 		return
 	}
+}
+
+func modifyComment(comment *ast.CommentGroup, prefix string) {
+	first := comment.List[0].Text
+	first = strings.TrimPrefix(first, "// ")
+	first = fmt.Sprintf(commentBase+"%s", prefix, first)
+	comment.List[0].Text = first
 }

--- a/parse.go
+++ b/parse.go
@@ -168,7 +168,13 @@ func addTypeSpecComment(gd *ast.GenDecl, ts *ast.TypeSpec, commentTemplate strin
 }
 
 func modifyComment(comment *ast.CommentGroup, prefix string) {
+	commentTemplate := commentBase + *template
 	first := comment.List[0].Text
+	if strings.HasPrefix(first, "//") && !strings.HasPrefix(first, "// ") {
+		text := fmt.Sprintf(commentTemplate, prefix)
+		comment.List = append([]*ast.Comment{{Text: text, Slash: comment.Pos()}}, comment.List...)
+		return
+	}
 	first = strings.TrimPrefix(first, "// ")
 	first = fmt.Sprintf(commentBase+"%s", prefix, first)
 	comment.List[0].Text = first

--- a/parse.go
+++ b/parse.go
@@ -42,7 +42,7 @@ func parseFile(fset *token.FileSet, filePath, template string) (af *ast.File, mo
 				return true
 			}
 			addFuncDeclComment(typ, commentTemplate)
-			cmap[typ] = []*ast.CommentGroup{typ.Doc}
+			cmap[typ] = appendCommentGroup(cmap[typ], typ.Doc)
 
 		case *ast.DeclStmt:
 			skipped[typ.Decl] = true
@@ -59,7 +59,7 @@ func parseFile(fset *token.FileSet, filePath, template string) (af *ast.File, mo
 								continue
 							}
 							addParenValueSpecComment(vs, commentTemplate)
-							cmap[vs] = []*ast.CommentGroup{vs.Doc}
+							cmap[vs] = appendCommentGroup(cmap[vs], vs.Doc)
 						}
 						return true
 					}
@@ -85,7 +85,7 @@ func parseFile(fset *token.FileSet, filePath, template string) (af *ast.File, mo
 			default:
 				return true
 			}
-			cmap[typ] = []*ast.CommentGroup{typ.Doc}
+			cmap[typ] = appendCommentGroup(cmap[typ], typ.Doc)
 		}
 		return true
 	})

--- a/parse.go
+++ b/parse.go
@@ -116,7 +116,7 @@ func addFuncDeclComment(fd *ast.FuncDecl, commentTemplate string) {
 	}
 	if fd.Doc != nil && !strings.HasPrefix(strings.TrimSpace(fd.Doc.Text()), fd.Name.Name) && isDouble(fd.Doc) {
 		log.Println(fd.Doc.List[0].Text)
-		text := fmt.Sprintf("\n// %s %s", fd.Name, strings.TrimSpace(fd.Doc.Text()))
+		text := fmt.Sprintf(commentBase + "%s", fd.Name, strings.TrimSpace(fd.Doc.Text()))
 		pos := fd.Pos() - token.Pos(1)
 		if fd.Doc != nil {
 			pos = fd.Doc.Pos()

--- a/parse.go
+++ b/parse.go
@@ -5,7 +5,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"log"
 	"strings"
 )
 
@@ -114,12 +113,8 @@ func addFuncDeclComment(fd *ast.FuncDecl, commentTemplate string) {
 		return
 	}
 	if fd.Doc != nil && !strings.HasPrefix(strings.TrimSpace(fd.Doc.Text()), fd.Name.Name) && isLineComment(fd.Doc) {
-		log.Println(fd.Doc.List[0].Text)
 		text := fmt.Sprintf(commentBase+"%s", fd.Name, strings.TrimSpace(fd.Doc.Text()))
-		pos := fd.Pos() - token.Pos(1)
-		if fd.Doc != nil {
-			pos = fd.Doc.Pos()
-		}
+		pos := fd.Doc.Pos()
 		fd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
 		return
 	}
@@ -133,6 +128,13 @@ func addValueSpecComment(gd *ast.GenDecl, vs *ast.ValueSpec, commentTemplate str
 			pos = gd.Doc.Pos()
 		}
 		gd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
+		return
+	}
+	if gd.Doc != nil && isLineComment(gd.Doc) && !hasPrefix(gd.Doc, vs.Names[0].Name) {
+		text := fmt.Sprintf(commentBase+"%s", vs.Names[0].Name, strings.TrimSpace(gd.Doc.Text()))
+		pos := gd.Doc.Pos()
+		gd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
+		return
 	}
 }
 

--- a/parse.go
+++ b/parse.go
@@ -147,6 +147,13 @@ func addParenValueSpecComment(vs *ast.ValueSpec, commentTemplate string) {
 			pos = vs.Doc.Pos()
 		}
 		vs.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
+		return
+	}
+	if vs.Doc != nil && isLineComment(vs.Doc) && !hasPrefix(vs.Doc, vs.Names[0].Name) {
+		text := fmt.Sprintf(commentBase+"%s", vs.Names[0].Name, strings.TrimSpace(vs.Doc.Text()))
+		pos := vs.Doc.Pos()
+		vs.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
+		return
 	}
 }
 

--- a/parse.go
+++ b/parse.go
@@ -26,7 +26,12 @@ func parseFile(fset *token.FileSet, filePath, template string) (af *ast.File, mo
 	}
 
 	commentTemplate := commentBase + template
-	numComments := len(af.Comments)
+
+	originalCommentSign := ""
+	for _, c := range af.Comments {
+		originalCommentSign += c.Text()
+	}
+
 	cmap := ast.NewCommentMap(fset, af, af.Comments)
 
 	skipped := make(map[ast.Node]bool)
@@ -87,7 +92,14 @@ func parseFile(fset *token.FileSet, filePath, template string) (af *ast.File, mo
 
 	// Rebuild comments
 	af.Comments = cmap.Filter(af).Comments()
-	modified = len(af.Comments) > numComments
+
+	currentCommentSign := ""
+	for _, c := range af.Comments {
+		currentCommentSign += c.Text()
+	}
+
+
+	modified = currentCommentSign != originalCommentSign
 	return
 }
 

--- a/parse.go
+++ b/parse.go
@@ -5,6 +5,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"log"
 	"strings"
 )
 
@@ -111,8 +112,18 @@ func addFuncDeclComment(fd *ast.FuncDecl, commentTemplate string) {
 			pos = fd.Doc.Pos()
 		}
 		fd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
+		return
 	}
-
+	if fd.Doc != nil && !strings.HasPrefix(strings.TrimSpace(fd.Doc.Text()), fd.Name.Name) && isDouble(fd.Doc) {
+		log.Println(fd.Doc.List[0].Text)
+		text := fmt.Sprintf("\n// %s %s", fd.Name, strings.TrimSpace(fd.Doc.Text()))
+		pos := fd.Pos() - token.Pos(1)
+		if fd.Doc != nil {
+			pos = fd.Doc.Pos()
+		}
+		fd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
+		return
+	}
 }
 
 func addValueSpecComment(gd *ast.GenDecl, vs *ast.ValueSpec, commentTemplate string) {

--- a/parse.go
+++ b/parse.go
@@ -112,7 +112,7 @@ func addFuncDeclComment(fd *ast.FuncDecl, commentTemplate string) {
 		fd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
 		return
 	}
-	if fd.Doc != nil && !strings.HasPrefix(strings.TrimSpace(fd.Doc.Text()), fd.Name.Name) && isLineComment(fd.Doc) {
+	if fd.Doc != nil && isLineComment(fd.Doc) && !hasCommentPrefix(fd.Doc, fd.Name.Name) {
 		text := fmt.Sprintf(commentBase+"%s", fd.Name, strings.TrimSpace(fd.Doc.Text()))
 		pos := fd.Doc.Pos()
 		fd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
@@ -130,7 +130,7 @@ func addValueSpecComment(gd *ast.GenDecl, vs *ast.ValueSpec, commentTemplate str
 		gd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
 		return
 	}
-	if gd.Doc != nil && isLineComment(gd.Doc) && !hasPrefix(gd.Doc, vs.Names[0].Name) {
+	if gd.Doc != nil && isLineComment(gd.Doc) && !hasCommentPrefix(gd.Doc, vs.Names[0].Name) {
 		text := fmt.Sprintf(commentBase+"%s", vs.Names[0].Name, strings.TrimSpace(gd.Doc.Text()))
 		pos := gd.Doc.Pos()
 		gd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
@@ -149,7 +149,7 @@ func addParenValueSpecComment(vs *ast.ValueSpec, commentTemplate string) {
 		vs.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
 		return
 	}
-	if vs.Doc != nil && isLineComment(vs.Doc) && !hasPrefix(vs.Doc, vs.Names[0].Name) {
+	if vs.Doc != nil && isLineComment(vs.Doc) && !hasCommentPrefix(vs.Doc, vs.Names[0].Name) {
 		text := fmt.Sprintf(commentBase+"%s", vs.Names[0].Name, strings.TrimSpace(vs.Doc.Text()))
 		pos := vs.Doc.Pos()
 		vs.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
@@ -167,7 +167,7 @@ func addTypeSpecComment(gd *ast.GenDecl, ts *ast.TypeSpec, commentTemplate strin
 		gd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
 		return
 	}
-	if gd.Doc != nil && isLineComment(gd.Doc) && !hasPrefix(gd.Doc, ts.Name.Name) {
+	if gd.Doc != nil && isLineComment(gd.Doc) && !hasCommentPrefix(gd.Doc, ts.Name.Name) {
 		text := fmt.Sprintf(commentBase+"%s", ts.Name.Name, strings.TrimSpace(gd.Doc.Text()))
 		pos := gd.Doc.Pos()
 		gd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}

--- a/parse.go
+++ b/parse.go
@@ -99,7 +99,6 @@ func parseFile(fset *token.FileSet, filePath, template string) (af *ast.File, mo
 		currentCommentSign += c.Text()
 	}
 
-
 	modified = currentCommentSign != originalCommentSign
 	return
 }
@@ -114,9 +113,9 @@ func addFuncDeclComment(fd *ast.FuncDecl, commentTemplate string) {
 		fd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
 		return
 	}
-	if fd.Doc != nil && !strings.HasPrefix(strings.TrimSpace(fd.Doc.Text()), fd.Name.Name) && isDouble(fd.Doc) {
+	if fd.Doc != nil && !strings.HasPrefix(strings.TrimSpace(fd.Doc.Text()), fd.Name.Name) && isLineComment(fd.Doc) {
 		log.Println(fd.Doc.List[0].Text)
-		text := fmt.Sprintf(commentBase + "%s", fd.Name, strings.TrimSpace(fd.Doc.Text()))
+		text := fmt.Sprintf(commentBase+"%s", fd.Name, strings.TrimSpace(fd.Doc.Text()))
 		pos := fd.Pos() - token.Pos(1)
 		if fd.Doc != nil {
 			pos = fd.Doc.Pos()

--- a/parse.go
+++ b/parse.go
@@ -165,5 +165,12 @@ func addTypeSpecComment(gd *ast.GenDecl, ts *ast.TypeSpec, commentTemplate strin
 			pos = gd.Doc.Pos()
 		}
 		gd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
+		return
+	}
+	if gd.Doc != nil && isLineComment(gd.Doc) && !hasPrefix(gd.Doc, ts.Name.Name) {
+		text := fmt.Sprintf(commentBase+"%s", ts.Name.Name, strings.TrimSpace(gd.Doc.Text()))
+		pos := gd.Doc.Pos()
+		gd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
+		return
 	}
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -129,6 +129,11 @@ func CommentExistedWithSpace() {
 func CommentExistedWithWrong() {
 }
 
+// CommentExistedWithWrong2 multi-line comments
+// something
+func CommentExistedWithWrong2() {
+}
+
 /*
 something
 */
@@ -141,10 +146,14 @@ var ValueWithExistedComment1 = 1
 // ValueWithExistedComment2 existed comment with spaces
 var ValueWithExistedComment2 = 1
 
+// ValueWithExistedComment3 multi-line comments
+// something
+var ValueWithExistedComment3 = 1
+
 /*
 should't change C style comment
 */
-var ValueWithExistedComment3 = 1
+var ValueWithExistedComment4 = 1
 
 // ParenValueWithExistedComment1 existed comment
 const (
@@ -153,16 +162,28 @@ const (
 	ParenValueWithExistedComment2 = 1
 )
 
+// ParenValueWithExistedComment3 multi-line comments
+// something
+const (
+	ParenValueWithExistedComment3 = 1
+	// ParenValueWithExistedComment2 something
+	ParenValueWithExistedComment4 = 1
+)
+
 // TypeWithExistedComment1 existed comment
 type TypeWithExistedComment1 int
 
 // TypeWithExistedComment2 existed comment with spaces
 type TypeWithExistedComment2 int
 
+// TypeWithExistedComment3 multi-line comments
+// something
+type TypeWithExistedComment3 int
+
 /*
 should't change C style comment
 */
-type TypeWithExistedComment3 int
+type TypeWithExistedComment4 int
 `
 
 func Test_parseFile(t *testing.T) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -152,6 +152,17 @@ const (
 	// ParenValueWithExistedComment2 something
 	ParenValueWithExistedComment2 = 1
 )
+
+// TypeWithExistedComment1 existed comment
+type TypeWithExistedComment1 int
+
+// TypeWithExistedComment2 existed comment with spaces
+type TypeWithExistedComment2 int
+
+/*
+should't change C style comment
+*/
+type TypeWithExistedComment3 int
 `
 
 func Test_parseFile(t *testing.T) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -134,6 +134,17 @@ something
 */
 func CommentWrongByDontChange() {
 }
+
+// ValueWithExistedComment1 existed comment
+var ValueWithExistedComment1 = 1
+
+// ValueWithExistedComment2 existed comment with spaces
+var ValueWithExistedComment2 = 1
+
+/*
+should't change C style comment
+*/
+var ValueWithExistedComment3 = 1
 `
 
 func Test_parseFile(t *testing.T) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -117,6 +117,8 @@ func a() {
 
 const existed = `package p
 
+import "embed"
+
 // CommentExisted ...
 func CommentExisted() {
 }
@@ -184,6 +186,20 @@ type TypeWithExistedComment3 int
 should't change C style comment
 */
 type TypeWithExistedComment4 int
+
+// Embed ...
+//go:embed dont_modify_this_comment.txt
+//go:embed image/*
+var Embed embed.FS
+
+// Embed something
+//go:embed dont_modify_this_comment.txt
+var Embed embed.FS
+
+// Generate ...
+//go:generate goyacc -o gopher.go -p parser gopher.y
+func Generate() {
+}
 `
 
 func Test_parseFile(t *testing.T) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -145,6 +145,13 @@ var ValueWithExistedComment2 = 1
 should't change C style comment
 */
 var ValueWithExistedComment3 = 1
+
+// ParenValueWithExistedComment1 existed comment
+const (
+	ParenValueWithExistedComment1 = 1
+	// ParenValueWithExistedComment2 something
+	ParenValueWithExistedComment2 = 1
+)
 `
 
 func Test_parseFile(t *testing.T) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -117,30 +117,43 @@ func a() {
 
 const existed = `package p
 
+// global comments should never be deleted
+// something
+
 import "embed"
 
-// CommentExisted ...
-func CommentExisted() {
+// global comment 1
+
+// global comment 2
+// global comment 3
+
+// ============= function =============
+
+// FuncWithExistedComment1 ...
+func FuncWithExistedComment1() {
 }
 
-// CommentExistedWithSpace ...
-func CommentExistedWithSpace() {
+// FuncWithExistedComment2 ...
+func FuncWithExistedComment2() {
+	// this comments should never be deleted
 }
 
-// CommentExistedWithWrong something
-func CommentExistedWithWrong() {
+// FuncWithExistedComment3 something
+func FuncWithExistedComment3() {
 }
 
-// CommentExistedWithWrong2 multi-line comments
+// FuncWithExistedComment4 multi-line comments
 // something
-func CommentExistedWithWrong2() {
+func FuncWithExistedComment4() {
 }
 
 /*
 something
 */
-func CommentWrongByDontChange() {
+func FuncWithExistedComment5() {
 }
+
+// ============= value =============
 
 // ValueWithExistedComment1 existed comment
 var ValueWithExistedComment1 = 1
@@ -157,6 +170,8 @@ should't change C style comment
 */
 var ValueWithExistedComment4 = 1
 
+// ============= paren value =============
+
 // ParenValueWithExistedComment1 existed comment
 const (
 	ParenValueWithExistedComment1 = 1
@@ -171,6 +186,8 @@ const (
 	// ParenValueWithExistedComment2 something
 	ParenValueWithExistedComment4 = 1
 )
+
+// ============= type =============
 
 // TypeWithExistedComment1 existed comment
 type TypeWithExistedComment1 int
@@ -187,6 +204,8 @@ should't change C style comment
 */
 type TypeWithExistedComment4 int
 
+// ============= marker comment =============
+
 // Embed ...
 //go:embed dont_modify_this_comment.txt
 //go:embed image/*
@@ -200,6 +219,8 @@ var Embed embed.FS
 //go:generate goyacc -o gopher.go -p parser gopher.y
 func Generate() {
 }
+
+// ============= end =============
 `
 
 func Test_parseFile(t *testing.T) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -124,6 +124,16 @@ func CommentExisted() {
 // CommentExistedWithSpace ...
 func CommentExistedWithSpace() {
 }
+
+// CommentExistedWithWrong something
+func CommentExistedWithWrong() {
+}
+
+/*
+something
+*/
+func CommentWrongByDontChange() {
+}
 `
 
 func Test_parseFile(t *testing.T) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -115,6 +115,17 @@ func a() {
 	log.Println(LogAll)
 }`
 
+const existed = `package p
+
+// CommentExisted ...
+func CommentExisted() {
+}
+
+// CommentExistedWithSpace ...
+func CommentExistedWithSpace() {
+}
+`
+
 func Test_parseFile(t *testing.T) {
 	parseFileTests := []struct {
 		path        string
@@ -126,6 +137,7 @@ func Test_parseFile(t *testing.T) {
 		{"testdata/parenthesis.go", parenSrc, true, false},
 		{"testdata/invalid_file.go", "", false, true},
 		{"testdata/issue7.go", issue7, false, false},
+		{"testdata/existed.go", existed, true, false},
 	}
 
 	for _, tc := range parseFileTests {

--- a/testdata/existed.go
+++ b/testdata/existed.go
@@ -28,3 +28,10 @@ var ValueWithExistedComment2 = 1
 should't change C style comment
 */
 var ValueWithExistedComment3 = 1
+
+// existed comment
+const (
+	ParenValueWithExistedComment1 = 1
+	// ParenValueWithExistedComment2 something
+	ParenValueWithExistedComment2 = 1
+)

--- a/testdata/existed.go
+++ b/testdata/existed.go
@@ -17,3 +17,14 @@ something
 */
 func CommentWrongByDontChange() {
 }
+
+// existed comment
+var ValueWithExistedComment1 = 1
+
+// existed comment with spaces     
+var ValueWithExistedComment2 = 1
+
+/*
+should't change C style comment
+*/
+var ValueWithExistedComment3 = 1

--- a/testdata/existed.go
+++ b/testdata/existed.go
@@ -7,3 +7,13 @@ func CommentExisted() {
 // CommentExistedWithSpace 
 func CommentExistedWithSpace() {
 }
+
+// something
+func CommentExistedWithWrong() {
+}
+
+/*
+something
+*/
+func CommentWrongByDontChange() {
+}

--- a/testdata/existed.go
+++ b/testdata/existed.go
@@ -1,5 +1,7 @@
 package p
 
+import "embed"
+
 // CommentExisted
 func CommentExisted() {
 }
@@ -67,3 +69,15 @@ type TypeWithExistedComment3 int
 should't change C style comment
 */
 type TypeWithExistedComment4 int
+
+//go:embed dont_modify_this_comment.txt
+//go:embed image/*
+var Embed embed.FS
+
+// something
+//go:embed dont_modify_this_comment.txt
+var Embed embed.FS
+
+//go:generate goyacc -o gopher.go -p parser gopher.y
+func Generate() {
+}

--- a/testdata/existed.go
+++ b/testdata/existed.go
@@ -12,6 +12,11 @@ func CommentExistedWithSpace() {
 func CommentExistedWithWrong() {
 }
 
+// multi-line comments
+// something
+func CommentExistedWithWrong2() {
+}
+
 /*
 something
 */
@@ -24,10 +29,14 @@ var ValueWithExistedComment1 = 1
 // existed comment with spaces     
 var ValueWithExistedComment2 = 1
 
+// multi-line comments
+// something
+var ValueWithExistedComment3 = 1
+
 /*
 should't change C style comment
 */
-var ValueWithExistedComment3 = 1
+var ValueWithExistedComment4 = 1
 
 // existed comment
 const (
@@ -36,13 +45,25 @@ const (
 	ParenValueWithExistedComment2 = 1
 )
 
+// multi-line comments
+// something
+const (
+	ParenValueWithExistedComment3 = 1
+	// ParenValueWithExistedComment2 something
+	ParenValueWithExistedComment4 = 1
+)
+
 // existed comment
 type TypeWithExistedComment1 int
 
 // existed comment with spaces     
 type TypeWithExistedComment2 int
 
+// multi-line comments
+// something
+type TypeWithExistedComment3 int
+
 /*
 should't change C style comment
 */
-type TypeWithExistedComment3 int
+type TypeWithExistedComment4 int

--- a/testdata/existed.go
+++ b/testdata/existed.go
@@ -35,3 +35,14 @@ const (
 	// ParenValueWithExistedComment2 something
 	ParenValueWithExistedComment2 = 1
 )
+
+// existed comment
+type TypeWithExistedComment1 int
+
+// existed comment with spaces     
+type TypeWithExistedComment2 int
+
+/*
+should't change C style comment
+*/
+type TypeWithExistedComment3 int

--- a/testdata/existed.go
+++ b/testdata/existed.go
@@ -1,0 +1,9 @@
+package p
+
+// CommentExisted
+func CommentExisted() {
+}
+
+// CommentExistedWithSpace 
+func CommentExistedWithSpace() {
+}

--- a/testdata/existed.go
+++ b/testdata/existed.go
@@ -1,29 +1,41 @@
 package p
 
+// global comments should never be deleted
+// something
+
 import "embed"
 
-// CommentExisted
-func CommentExisted() {
+// global comment 1
+
+// global comment 2
+// global comment 3
+
+// ============= function =============
+
+// FuncWithExistedComment1
+func FuncWithExistedComment1() {
 }
 
-// CommentExistedWithSpace 
-func CommentExistedWithSpace() {
+func FuncWithExistedComment2() {
+	// this comments should never be deleted
 }
 
 // something
-func CommentExistedWithWrong() {
+func FuncWithExistedComment3() {
 }
 
 // multi-line comments
 // something
-func CommentExistedWithWrong2() {
+func FuncWithExistedComment4() {
 }
 
 /*
 something
 */
-func CommentWrongByDontChange() {
+func FuncWithExistedComment5() {
 }
+
+// ============= value =============
 
 // existed comment
 var ValueWithExistedComment1 = 1
@@ -40,6 +52,8 @@ should't change C style comment
 */
 var ValueWithExistedComment4 = 1
 
+// ============= paren value =============
+
 // existed comment
 const (
 	ParenValueWithExistedComment1 = 1
@@ -54,6 +68,8 @@ const (
 	// ParenValueWithExistedComment2 something
 	ParenValueWithExistedComment4 = 1
 )
+
+// ============= type =============
 
 // existed comment
 type TypeWithExistedComment1 int
@@ -70,6 +86,8 @@ should't change C style comment
 */
 type TypeWithExistedComment4 int
 
+// ============= marker comment =============
+
 //go:embed dont_modify_this_comment.txt
 //go:embed image/*
 var Embed embed.FS
@@ -81,3 +99,5 @@ var Embed embed.FS
 //go:generate goyacc -o gopher.go -p parser gopher.y
 func Generate() {
 }
+
+// ============= end =============


### PR DESCRIPTION
### Add the missed name prefix to the existed comment

Original code:

```go
// find user from database
func FindUser() {
}
```

Using `gocmt` give you:

```go
// FindUser find user from database
func FindUser() {
}
```

### Make existed comment to fit the template

Original code:

```go
// User
type User struct {
}
```

Using `gocmt` give you:

```go
// User ...
type User struct {
}
```

### Works well in multi-line comment

Original code:

```go
// it causes when a connection failed.
// you should retry the query in most time.
var ConnectFailed = errors.new("failed to connect")
```

Using `gocmt` give you:

```go
// QueryFailed it causes when a connection failed.
// you should retry the query in most time.
var QueryFailed = errors.new("failed to query")
```

### Take care of the marker comment

Original code:

```go
//go:embed storage/*
var LocalCache embed.FS

// never change this manually
//go:generate goyacc -o gopher.go -p parser gopher.y
func Generate() {
}

//binding:config-maker
type Maker struct {}
```

Using `gocmt` give you:

```go
// LocalCache ...
//go:embed storage/*
var LocalCache embed.FS

// Generate never change this manually
//go:generate goyacc -o gopher.go -p parser gopher.y
func Generate() {
}

// Maker ...
//binding:config-maker
type Maker struct {}
```
