### PR TITLE
Bump minimum supported version to 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.19
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/cuonglm/gocmt
 
-go 1.16
+go 1.19
 
 require github.com/stretchr/testify v1.6.1
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"go/format"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -94,7 +93,7 @@ func processFile(filename, template string, inPlace bool) error {
 		newBuf = tralingWsRegex.ReplaceAll(newBuf, []byte(""))
 		newBuf = newlinesRegex.ReplaceAll(newBuf, []byte("\n\n"))
 		if inPlace {
-			return ioutil.WriteFile(filename, newBuf, defaultMode)
+			return os.WriteFile(filename, newBuf, defaultMode)
 		}
 
 		fmt.Fprintf(os.Stdout, "%s", newBuf)

--- a/parse_test.go
+++ b/parse_test.go
@@ -223,6 +223,12 @@ func Generate() {
 // ============= end =============
 `
 
+const generic = `package p
+
+// G ...
+type G[T any] struct{}
+`
+
 func Test_parseFile(t *testing.T) {
 	parseFileTests := []struct {
 		path        string
@@ -235,6 +241,7 @@ func Test_parseFile(t *testing.T) {
 		{"testdata/invalid_file.go", "", false, true},
 		{"testdata/issue7.go", issue7, false, false},
 		{"testdata/existed.go", existed, true, false},
+		{"testdata/generic.go", generic, true, false},
 	}
 
 	for _, tc := range parseFileTests {

--- a/testdata/generic.go
+++ b/testdata/generic.go
@@ -1,0 +1,3 @@
+package p
+
+type G[T any] struct{}


### PR DESCRIPTION
So we can parse generic code.

Fixes #18